### PR TITLE
Update build_linux.sh

### DIFF
--- a/build_linux.sh
+++ b/build_linux.sh
@@ -2,7 +2,7 @@
 
 PROGRAMS=("test_mpeg" "test_adx" "sfdmux")
 INCLUDES=-I./include
-LIBS="./lib/mpeg.c ./lib/utils.c ./lib/adx.c ./lib/sfd.c"
+LIBS="./lib/common.c ./lib/mpeg.c ./lib/utils.c ./lib/adx.c ./lib/sfd.c"
 ARGS="-Qn -O2 -s"
 
 mkdir bin


### PR DESCRIPTION
Requires common.c to be added to the LIBS definition, otherwise the `change_order_XX ` functions don't get recognized when compiling.

EDIT:
Actually, I think something else might be missing from the Linux script.
I'm currently working on re-editing some of the Metroid: Other M cutscenes, and when muxing the MPG with the 2 ADX files that such game uses with the compiled binary on Linux, makes the cutscene crash on the first couple of seconds when playing the file.

If I instead run the EXE through Wine on Linux, it muxes the file and the game plays it all the way through now, no issues.
Any idea what the issue might be for the Linux binary?